### PR TITLE
Add Bayesian models to HypothesisTest API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.5] - 2020-12-10
+### Changed
+- Add student models to HypothesisTest options
+
 ## [0.0.4] - 2020-11-25
 ### Changed
 - Update notebook dependency to address security vulnerability

--- a/abra/inference/__init__.py
+++ b/abra/inference/__init__.py
@@ -20,7 +20,9 @@ def get_inference_procedure(method, **infer_params):
         'bernoulli',
         'binomial',
         'beta_binomial',
-        'gamma_poisson'
+        'gamma_poisson',
+        'student_t',
+        'exp_student_t'
     ):
 
         from abra import BayesianDelta as IP

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ with open("README.md") as f:
 
 setup(
     name="abracadabra",
-    version="0.0.4",
-    description="Makes AB testing magically simple!",
+    version="0.0.5",
+    description="Making hypothesis and AB testing magically simple!",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     license="MIT",


### PR DESCRIPTION
# Objective
Access to the `student_t` and hierarchcial `exp_student_t` Bayesian models are missing as options in the top-level `HypothesisTest` API 🤦 . This PR adds them to the `get_inference_procedure` in `abra/inference/__init__.py`